### PR TITLE
Add initial GCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ Deploy a production-ready ChirpStack instance with all its core dependencies usi
 - **Mosquitto (MQTT Broker)** for device uplink/downlink messaging
 - **Load Balancer** for routing external traffic
 
-> ⚡ Deploy to Digital Ocean
+This repository originally targeted DigitalOcean. A new `main_gcp.tf` and accompanying modules
+provide experimental support for deploying the stack on Google Cloud Platform.

--- a/main_gcp.tf
+++ b/main_gcp.tf
@@ -1,0 +1,106 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    random = {
+      source = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+variable "gcp_project" { type = string }
+variable "gcp_region" { type = string }
+variable "gcp_zone" { type = string }
+variable "gcp_credentials" { type = string default = "" }
+
+variable "db_name" { type = string }
+variable "db_tier" { type = string }
+
+variable "redis_password" { type = string }
+variable "mosquitto_username" { type = string }
+variable "mosquitto_password" { type = string }
+
+variable "machine_type" { type = string }
+variable "instance_count" { type = number default = 2 }
+
+provider "google" {
+  project     = var.gcp_project
+  region      = var.gcp_region
+  zone        = var.gcp_zone
+  credentials = var.gcp_credentials == "" ? null : file(var.gcp_credentials)
+}
+
+module "network" {
+  source              = "./modules_gcp/network"
+  gcp_project         = var.gcp_project
+  gcp_region          = var.gcp_region
+  gcp_credentials     = var.gcp_credentials
+  gcp_vpc_name        = "lorawan-vpc"
+  gcp_domain          = ""
+  gcp_ssh_firewall_name = "ssh-fw"
+}
+
+module "postgres" {
+  source          = "./modules_gcp/postgres"
+  gcp_project     = var.gcp_project
+  gcp_region      = var.gcp_region
+  gcp_credentials = var.gcp_credentials
+  db_name         = var.db_name
+  db_tier         = var.db_tier
+}
+
+module "redis" {
+  source             = "./modules_gcp/redis"
+  gcp_project        = var.gcp_project
+  gcp_zone           = var.gcp_zone
+  gcp_credentials    = var.gcp_credentials
+  redis_instance_name = "redis"
+  machine_type       = var.machine_type
+  redis_password     = var.redis_password
+}
+
+module "mosquitto" {
+  source                = "./modules_gcp/mosquitto"
+  gcp_project           = var.gcp_project
+  gcp_zone              = var.gcp_zone
+  gcp_credentials       = var.gcp_credentials
+  mosquitto_instance_name = "mosquitto"
+  machine_type          = var.machine_type
+  mosquitto_username    = var.mosquitto_username
+  mosquitto_password    = var.mosquitto_password
+}
+
+module "chirpstack" {
+  source          = "./modules_gcp/chirpstack"
+  gcp_project     = var.gcp_project
+  gcp_zone        = var.gcp_zone
+  gcp_credentials = var.gcp_credentials
+  machine_type    = var.machine_type
+  instance_count  = var.instance_count
+
+  mosquitto_host     = module.mosquitto.mosquitto_host
+  mosquitto_port     = module.mosquitto.mosquitto_port
+  mosquitto_username = var.mosquitto_username
+  mosquitto_password = var.mosquitto_password
+
+  postgres_host     = module.postgres.postgres_credentials.host
+  postgres_db_name  = module.postgres.postgres_credentials.db_name
+  postgres_user     = module.postgres.postgres_credentials.user
+  postgres_password = module.postgres.postgres_credentials.password
+
+  redis_host     = module.redis.redis_host
+  redis_password = module.redis.redis_password
+}
+
+# Load balancer setup (optional)
+# module "loadbalancer" {
+#   source          = "./modules_gcp/loadbalancer"
+#   gcp_project     = var.gcp_project
+#   gcp_region      = var.gcp_region
+#   gcp_credentials = var.gcp_credentials
+#   lb_name         = "chirpstack-lb"
+#   instance_group  = google_compute_instance_group.default.self_link
+# }

--- a/modules_gcp/chirpstack/main.tf
+++ b/modules_gcp/chirpstack/main.tf
@@ -1,0 +1,76 @@
+variable "gcp_project" {
+  type = string
+}
+
+variable "gcp_zone" {
+  type = string
+}
+
+variable "gcp_credentials" {
+  type    = string
+  default = ""
+}
+
+variable "instance_count" {
+  type    = number
+  default = 2
+}
+
+variable "machine_type" {
+  type = string
+}
+
+variable "mosquitto_host" { type = string }
+variable "mosquitto_port" { type = string }
+variable "mosquitto_username" { type = string }
+variable "mosquitto_password" { type = string }
+
+variable "postgres_host" { type = string }
+variable "postgres_db_name" { type = string }
+variable "postgres_user" { type = string }
+variable "postgres_password" { type = string }
+
+variable "redis_host" { type = string }
+variable "redis_password" { type = string }
+
+provider "google" {
+  project     = var.gcp_project
+  zone        = var.gcp_zone
+  credentials = var.gcp_credentials == "" ? null : file(var.gcp_credentials)
+}
+
+resource "google_compute_instance" "chirpstack" {
+  count        = var.instance_count
+  name         = "chirpstack-${count.index}"
+  machine_type = var.machine_type
+  zone         = var.gcp_zone
+
+  boot_disk {
+    initialize_params { image = "ubuntu-os-cloud/ubuntu-2204-lts" }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {}
+  }
+
+  tags = ["chirpstack", "ssh"]
+
+  metadata_startup_script = <<-EOT
+    #!/bin/bash
+    apt-get update
+    apt-get install -y docker.io docker-compose git
+    git clone https://github.com/tofuhubhq/chirpstack-docker.git /opt/chirpstack
+    cat <<EOM >/opt/chirpstack/.env
+MQTT_BROKER_HOST=${var.mosquitto_username}:${var.mosquitto_password}@${var.mosquitto_host}
+POSTGRESQL_HOST=postgres://${var.postgres_user}:${var.postgres_password}@${var.postgres_host}:5432/${var.postgres_db_name}
+REDIS_HOST=default:${var.redis_password}@${var.redis_host}
+EOM
+    cd /opt/chirpstack
+    docker-compose up -d
+  EOT
+}
+
+output "chirpstack_ips" {
+  value = [for i in google_compute_instance.chirpstack : i.network_interface[0].access_config[0].nat_ip]
+}

--- a/modules_gcp/loadbalancer/main.tf
+++ b/modules_gcp/loadbalancer/main.tf
@@ -1,0 +1,52 @@
+variable "gcp_project" { type = string }
+variable "gcp_region" { type = string }
+variable "gcp_credentials" { type = string default = "" }
+variable "instance_group" { type = string }
+variable "lb_name" { type = string }
+
+provider "google" {
+  project     = var.gcp_project
+  region      = var.gcp_region
+  credentials = var.gcp_credentials == "" ? null : file(var.gcp_credentials)
+}
+
+resource "google_compute_health_check" "http" {
+  name               = "${var.lb_name}-hc"
+  check_interval_sec = 5
+  timeout_sec        = 5
+  http_health_check {
+    port = 8080
+    request_path = "/"
+  }
+}
+
+resource "google_compute_backend_service" "default" {
+  name                  = "${var.lb_name}-backend"
+  health_checks         = [google_compute_health_check.http.self_link]
+  protocol              = "HTTP"
+  port_name             = "http"
+  timeout_sec           = 10
+  backend {
+    group = var.instance_group
+  }
+}
+
+resource "google_compute_url_map" "default" {
+  name            = "${var.lb_name}-map"
+  default_service = google_compute_backend_service.default.self_link
+}
+
+resource "google_compute_target_http_proxy" "default" {
+  name    = "${var.lb_name}-proxy"
+  url_map = google_compute_url_map.default.self_link
+}
+
+resource "google_compute_global_forwarding_rule" "default" {
+  name       = var.lb_name
+  target     = google_compute_target_http_proxy.default.self_link
+  port_range = "80"
+}
+
+output "load_balancer_ip" {
+  value = google_compute_global_forwarding_rule.default.ip_address
+}

--- a/modules_gcp/mosquitto/main.tf
+++ b/modules_gcp/mosquitto/main.tf
@@ -1,0 +1,77 @@
+variable "gcp_project" {
+  type        = string
+  description = "GCP project ID"
+}
+
+variable "gcp_zone" {
+  type        = string
+  description = "GCP zone"
+}
+
+variable "gcp_credentials" {
+  type        = string
+  description = "Path to service account json"
+  default     = ""
+}
+
+variable "mosquitto_instance_name" {
+  type        = string
+  description = "Name for VM"
+}
+
+variable "machine_type" {
+  type        = string
+  description = "Machine type"
+}
+
+variable "mosquitto_username" {
+  type        = string
+}
+
+variable "mosquitto_password" {
+  type        = string
+}
+
+provider "google" {
+  project     = var.gcp_project
+  zone        = var.gcp_zone
+  credentials = var.gcp_credentials == "" ? null : file(var.gcp_credentials)
+}
+
+resource "google_compute_instance" "mosquitto" {
+  name         = var.mosquitto_instance_name
+  machine_type = var.machine_type
+  zone         = var.gcp_zone
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {}
+  }
+
+  tags = ["mosquitto", "ssh"]
+
+  metadata_startup_script = <<-EOT
+    #!/bin/bash
+    apt-get update
+    apt-get install -y mosquitto
+    mosquitto_passwd -b -c /etc/mosquitto/passwd "${var.mosquitto_username}" "${var.mosquitto_password}"
+    echo "allow_anonymous false" > /etc/mosquitto/conf.d/auth.conf
+    echo "password_file /etc/mosquitto/passwd" >> /etc/mosquitto/conf.d/auth.conf
+    systemctl restart mosquitto
+    systemctl enable mosquitto
+  EOT
+}
+
+output "mosquitto_host" {
+  value = google_compute_instance.mosquitto.network_interface[0].access_config[0].nat_ip
+}
+
+output "mosquitto_port" {
+  value = 1883
+}

--- a/modules_gcp/mosquitto/mosquitto.conf
+++ b/modules_gcp/mosquitto/mosquitto.conf
@@ -1,0 +1,1 @@
+bind_address 0.0.0.0

--- a/modules_gcp/network/main.tf
+++ b/modules_gcp/network/main.tf
@@ -1,0 +1,68 @@
+variable "gcp_project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "gcp_credentials" {
+  description = "Path to GCP service account key JSON"
+  type        = string
+  default     = ""
+}
+
+variable "gcp_vpc_name" {
+  description = "GCP VPC network name"
+  type        = string
+}
+
+variable "gcp_region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "gcp_domain" {
+  description = "Domain (managed zone must exist)"
+  type        = string
+  default     = ""
+}
+
+variable "gcp_ssh_firewall_name" {
+  description = "SSH firewall name"
+  type        = string
+  default     = ""
+}
+
+provider "google" {
+  project     = var.gcp_project
+  region      = var.gcp_region
+  credentials = var.gcp_credentials == "" ? null : file(var.gcp_credentials)
+}
+
+# Create the VPC network
+resource "google_compute_network" "main" {
+  name                    = var.gcp_vpc_name
+  auto_create_subnetworks = true
+}
+
+# Optional: reference an existing managed zone. The zone must already exist
+data "google_dns_managed_zone" "zone" {
+  count = var.gcp_domain == "" ? 0 : 1
+  name  = var.gcp_domain
+}
+
+resource "google_compute_firewall" "ssh" {
+  name    = var.gcp_ssh_firewall_name
+  network = google_compute_network.main.self_link
+
+  target_tags = ["ssh"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+output "network_name" {
+  value = google_compute_network.main.name
+}

--- a/modules_gcp/postgres/main.tf
+++ b/modules_gcp/postgres/main.tf
@@ -1,0 +1,67 @@
+variable "gcp_project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "gcp_region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "gcp_credentials" {
+  description = "Path to service account json"
+  type        = string
+  default     = ""
+}
+
+variable "db_name" {
+  description = "Database name"
+  type        = string
+}
+
+variable "db_tier" {
+  description = "Instance tier"
+  type        = string
+}
+
+provider "google" {
+  project     = var.gcp_project
+  region      = var.gcp_region
+  credentials = var.gcp_credentials == "" ? null : file(var.gcp_credentials)
+}
+
+resource "google_sql_database_instance" "postgres" {
+  name             = var.db_name
+  database_version = "POSTGRES_15"
+  region           = var.gcp_region
+
+  settings {
+    tier = var.db_tier
+  }
+}
+
+resource "google_sql_database" "db" {
+  name     = var.db_name
+  instance = google_sql_database_instance.postgres.name
+}
+
+resource "google_sql_user" "dbuser" {
+  name     = "chirpstack"
+  instance = google_sql_database_instance.postgres.name
+  password = random_password.password.result
+}
+
+resource "random_password" "password" {
+  length  = 16
+  special = false
+}
+
+output "postgres_credentials" {
+  value = {
+    host     = google_sql_database_instance.postgres.connection_name
+    user     = google_sql_user.dbuser.name
+    password = random_password.password.result
+    db_name  = google_sql_database.db.name
+  }
+  sensitive = true
+}

--- a/modules_gcp/redis/main.tf
+++ b/modules_gcp/redis/main.tf
@@ -1,0 +1,74 @@
+variable "gcp_project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "gcp_zone" {
+  description = "GCP zone"
+  type        = string
+}
+
+variable "gcp_credentials" {
+  description = "Path to service account json"
+  type        = string
+  default     = ""
+}
+
+variable "redis_instance_name" {
+  type        = string
+  description = "Name of redis VM"
+}
+
+variable "machine_type" {
+  type        = string
+  description = "GCE machine type"
+}
+
+variable "redis_password" {
+  type        = string
+  description = "Password to secure redis"
+}
+
+provider "google" {
+  project     = var.gcp_project
+  zone        = var.gcp_zone
+  credentials = var.gcp_credentials == "" ? null : file(var.gcp_credentials)
+}
+
+resource "google_compute_instance" "redis" {
+  name         = var.redis_instance_name
+  machine_type = var.machine_type
+  zone         = var.gcp_zone
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {}
+  }
+
+  tags = ["redis", "ssh"]
+
+  metadata_startup_script = <<-EOT
+    #!/bin/bash
+    apt-get update
+    apt-get install -y redis-server
+    sed -i "s/^#\\?requirepass .*/requirepass ${var.redis_password}/" /etc/redis/redis.conf
+    sed -i "s/^bind .*/bind 0.0.0.0/" /etc/redis/redis.conf
+    systemctl enable redis-server
+    systemctl restart redis-server
+  EOT
+}
+
+output "redis_host" {
+  value = google_compute_instance.redis.network_interface[0].access_config[0].nat_ip
+}
+
+output "redis_password" {
+  value     = var.redis_password
+  sensitive = true
+}


### PR DESCRIPTION
## Summary
- add experimental configuration files under `modules_gcp` for Google Cloud Platform
- provide new `main_gcp.tf` using these modules
- mention GCP support in the README

## Testing
- `tofu fmt -recursive` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878abced108832797f62fb90a137e8a